### PR TITLE
add option to set BC org.bouncycastle.asn1.allow_unsafe_integer

### DIFF
--- a/src/main/net/sf/portecle/DOptions.java
+++ b/src/main/net/sf/portecle/DOptions.java
@@ -79,6 +79,12 @@ class DOptions
 
 	/** Use look &amp; feel for window decoration? */
 	private boolean m_bLookFeelDecorated;
+	
+	/** Look &amp; feel decorated check box */
+	private JCheckBox m_jcbBcAllowUnsafeInteger;
+
+	/** Bouncy Castle Option Allow Unsafe Integer? */
+	private boolean m_bBcAllowUnsafeInteger;
 
 	/**
 	 * Creates new DOptions dialog.
@@ -86,12 +92,14 @@ class DOptions
 	 * @param parent The parent window
 	 * @param bUseCaCerts Use CA certificates keystore file?
 	 * @param fCaCertsFile CA certificates keystore file
+	 * @param bBcAllowUnsafeInteger BC Option AllowUnsafeInteger
 	 */
-	public DOptions(Window parent, boolean bUseCaCerts, File fCaCertsFile)
+	public DOptions(Window parent, boolean bUseCaCerts, File fCaCertsFile, boolean bBcAllowUnsafeInteger)
 	{
 		super(parent, true);
 		m_bUseCaCerts = bUseCaCerts;
 		m_fCaCertsFile = fCaCertsFile;
+		m_bBcAllowUnsafeInteger =bBcAllowUnsafeInteger;
 		initComponents();
 	}
 
@@ -215,6 +223,14 @@ class DOptions
 		jpLookFeel.add(jpLookFeelControls, BorderLayout.NORTH);
 		jpLookFeel.add(jpLookFeelDecoratedControls, BorderLayout.CENTER);
 		jpLookFeel.add(jpDecorationNote, BorderLayout.SOUTH);
+		
+		// Setup a BouncyCastle Options tab
+		JPanel jpBcOptions = new JPanel(new GridLayout(2, 1));
+		m_jcbBcAllowUnsafeInteger = new JCheckBox(RB.getString("DOptions.jpBCoptions.allowunsafeinteger.text"), m_bBcAllowUnsafeInteger);
+		m_jcbBcAllowUnsafeInteger.setToolTipText(RB.getString("DOptions.jpBCoptions.allowunsafeinteger.tooltip"));
+		jpBcOptions.add(m_jcbBcAllowUnsafeInteger, BorderLayout.NORTH);
+
+		
 
 		// Add the panels to a tabbed pane
 		JTabbedPane jtpOptions = new JTabbedPane();
@@ -222,6 +238,8 @@ class DOptions
 		    RB.getString("DOptions.jpCaCerts.tooltip"));
 		jtpOptions.addTab(RB.getString("DOptions.jpLookFeel.text"), null, jpLookFeel,
 		    RB.getString("DOptions.jpLookFeel.tooltip"));
+		jtpOptions.addTab(RB.getString("DOptions.jpBCoptions.text"), null, jpBcOptions,
+			RB.getString("DOptions.jpBCoptions.tooltip"));
 		jtpOptions.setBorder(new EmptyBorder(5, 5, 5, 5));
 
 		// OK and Cancel buttons
@@ -261,6 +279,8 @@ class DOptions
 
 		// Store whether or not look & feel decoration should be used
 		m_bLookFeelDecorated = m_jcbLookFeelDecorated.isSelected();
+		
+		m_bBcAllowUnsafeInteger =m_jcbBcAllowUnsafeInteger.isSelected();
 	}
 
 	/**
@@ -342,5 +362,19 @@ class DOptions
 	{
 		storeOptions();
 		super.okPressed();
+	}
+
+	/** 
+	 * Preference: is option enabled to allow BC do relaxed integer parsing?
+	 * @return True if option may be enabled, false otherwise.
+	 */
+	public boolean isBcAllowUnsafeInteger()
+	{
+		return m_bBcAllowUnsafeInteger;
+	}
+
+	public void setBcAllowUnsafeInteger(boolean m_bBcAllowUnsafeInteger)
+	{
+		this.m_bBcAllowUnsafeInteger =m_bBcAllowUnsafeInteger;
 	}
 }

--- a/src/main/net/sf/portecle/FPortecle.java
+++ b/src/main/net/sf/portecle/FPortecle.java
@@ -221,6 +221,10 @@ public class FPortecle
 	/** Look &amp; Feel setting made in options (picked up by saveAppPrefs) */
 	private Boolean m_bLookFeelDecorationOptions;
 
+	/** Preference: allowed to set BC org.bouncycastle.asn1.allow_unsafe_integer  
+            made in options (picked up by saveAppPrefs) */
+	private Boolean m_bBouncyCastleAllowUnsafeInteger;
+
 	/** Currently selected alias */
 	private String selectedAlias;
 
@@ -352,6 +356,12 @@ public class FPortecle
 		m_bUseCaCerts = PREFS.getBoolean(RB.getString("AppPrefs.UseCaCerts"), false);
 		m_fCaCertsFile =
 		    new File(PREFS.get(RB.getString("AppPrefs.CaCertsFile"), DEFAULT_CA_CERTS_FILE.getAbsolutePath()));
+		
+		m_bBouncyCastleAllowUnsafeInteger = PREFS.getBoolean(RB.getString("AppPrefs.BouncyCastleAllowUnsafeInteger"), false);
+		if(m_bBouncyCastleAllowUnsafeInteger)
+		{
+			System.getProperties().setProperty(RB.getString("AppPrefs.BouncyCastleAllowUnsafeIntegerOption"), "true");
+		}
 
 		// Initialize GUI components
 		initComponents();
@@ -3614,7 +3624,7 @@ public class FPortecle
 	 */
 	private void showOptions()
 	{
-		DOptions dOptions = new DOptions(this, m_bUseCaCerts, m_fCaCertsFile);
+		DOptions dOptions = new DOptions(this, m_bUseCaCerts, m_fCaCertsFile, m_bBouncyCastleAllowUnsafeInteger);
 		dOptions.setLocationRelativeTo(this);
 		SwingHelper.showAndWait(dOptions);
 
@@ -3633,6 +3643,18 @@ public class FPortecle
 
 		// Use CA certificates?
 		m_bUseCaCerts = dOptions.isUseCaCerts();
+		
+		// Allowed to set option for BC
+		m_bBouncyCastleAllowUnsafeInteger =dOptions.isBcAllowUnsafeInteger();
+		if(m_bBouncyCastleAllowUnsafeInteger)
+		{
+			System.getProperties().setProperty(RB.getString("AppPrefs.BouncyCastleAllowUnsafeIntegerOption"), "true");
+		}
+		else
+		{
+			System.getProperties().remove(RB.getString("AppPrefs.BouncyCastleAllowUnsafeIntegerOption"));
+		}
+
 
 		// Look & feel
 		String newLookFeelClassName = dOptions.getLookFeelClassName();
@@ -5659,6 +5681,12 @@ public class FPortecle
 			{
 				// Current setting
 				PREFS.putBoolean(RB.getString("AppPrefs.LookFeelDecor"), JFrame.isDefaultLookAndFeelDecorated());
+			}
+			
+			if (m_bBouncyCastleAllowUnsafeInteger != null)
+			{
+				// Setting made in options
+				PREFS.putBoolean(RB.getString("AppPrefs.BouncyCastleAllowUnsafeInteger"), m_bBouncyCastleAllowUnsafeInteger);
 			}
 
 			PREFS.sync();

--- a/src/main/net/sf/portecle/resources.properties
+++ b/src/main/net/sf/portecle/resources.properties
@@ -35,6 +35,10 @@ AppPrefs.AliasWidth=aliaswidth
 AppPrefs.RecentFile=recentfile
 AppPrefs.LookFeel=lookfeel
 AppPrefs.LookFeelDecor=lookfeeldecor
+AppPrefs.BouncyCastleAllowUnsafeInteger=bouncycastleallowunsafeinteger
+
+# the option for BC
+AppPrefs.BouncyCastleAllowUnsafeIntegerOption=org.bouncycastle.asn1.allow_unsafe_integer
 
 ############################################################################
 # Portecle Resources
@@ -1038,6 +1042,8 @@ DOptions.jpLookFeel.text=Look & Feel
 DOptions.jlLookFeel.text=Look & Feel:
 DOptions.m_jcbLookFeelDecorated.text=Use window decorations provided by Look & Feel?
 DOptions.jlDecorationNote.text=Changing the decoration setting will affect newly created windows only.
+DOptions.jpBCoptions.text=BC Options
+DOptions.jpBCoptions.allowunsafeinteger.text=Allow Unsafe Integer decoding. Allow parsing of malformed ASN.1 integers in a similar fashion to what BC 1.56 did.  
 
 # Mnemonics
 DOptions.jbBrowseCaCertsFile.mnemonic=B
@@ -1052,6 +1058,8 @@ DOptions.jbResetCaCertsFile.tooltip=Reset CA Certs Keystore location to default
 DOptions.jpLookFeel.tooltip=Change the Look & Feel of the application
 DOptions.m_jcbLookFeel.tooltip=Look & Feel to use for application
 DOptions.m_jcbLookFeelDecorated.tooltip=Use the Look & Feel's window decoration (when available)?
+DOptions.jpBCoptions.tooltip=Options for the BouncyCastle security provider
+DOptions.jpBCoptions.allowunsafeinteger.tooltip=Relax strict integer decoding in BC 1.58+
 
 ############################################################################
 # KeyStoreTableModel Resources


### PR DESCRIPTION
fix for issue #60

This commit adds an option to Portecle that lets the user decide setting org.bouncycastle.asn1.allow_unsafe_integer or not.

![image](https://user-images.githubusercontent.com/48212437/53823136-6df2e500-3f71-11e9-80a3-bbc369d4bd70.png)

Attached zip holds a PKCS12 store containing one malformed certificate as received from a communication partner. Keystore password is: one
[one-malformed-certificate.zip](https://github.com/scop/portecle/files/2931964/one-malformed-certificate.zip)
